### PR TITLE
fix copy-paste error in comment

### DIFF
--- a/collector/stat_linux.go
+++ b/collector/stat_linux.go
@@ -43,7 +43,7 @@ func init() {
 }
 
 // Takes a prometheus registry and returns a new Collector exposing
-// network device stats.
+// kernel/system statistics.
 func NewStatCollector() (Collector, error) {
 	return &statCollector{
 		cpu: prometheus.NewCounterVec(


### PR DESCRIPTION
Comment seems to be copied from netdev_linux.go, where it is correct.